### PR TITLE
chore: loosen dependency specifications where reasonable

### DIFF
--- a/attendease_sdk.gemspec
+++ b/attendease_sdk.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0", ">= 13.0.6"
   spec.add_development_dependency "rspec", "~> 2.12"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry", "~> 0"
 
-  spec.add_dependency "httparty", "~> 0.13.7"
-  spec.add_dependency "activesupport", "~> 3.2.22.2"
+  spec.add_dependency "httparty", "~> 0.13", ">= 0.13.7"
+  spec.add_dependency "activesupport", "~> 3.2.22", ">= 3.2.22.2"
 end

--- a/lib/attendease_sdk/version.rb
+++ b/lib/attendease_sdk/version.rb
@@ -1,3 +1,3 @@
 module AttendeaseSDK
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
This pull request makes updates to two dependencies, changing their version specification to be looser than what the original pessimistic operator allowed for:

- **rake**: version specification changed from `"~> 10.0"` to `"~> 13.0", ">= 13.0.6"`. There do no appear to be any breaking changes between 10.0 and 13.0.6, according to the [changelog](https://github.com/ruby/rake/blob/v13.2.1/History.rdoc).
- **httparty**: version specification changed from `"~> 0.13.7"` to `"~> 0.13", ">= 0.13.7"`, which allows it to be upgraded to v0.22.0 in the context of the applications that rely on this SDK.